### PR TITLE
Fix build with nginx 1.11.6

### DIFF
--- a/src/ngx_postgres_module.c
+++ b/src/ngx_postgres_module.c
@@ -1320,6 +1320,7 @@ ngx_postgres_find_upstream(ngx_http_request_t *r, ngx_url_t *url)
             continue;
         }
 
+  #if (nginx_version < 1011006)
         if (uscfp[i]->default_port && url->default_port
             && (uscfp[i]->default_port != url->default_port))
         {
@@ -1327,6 +1328,7 @@ ngx_postgres_find_upstream(ngx_http_request_t *r, ngx_url_t *url)
             continue;
         }
 
+  #endif
         dd("returning");
         return uscfp[i];
     }


### PR DESCRIPTION
default_port was removed from ngx_http_upstream_srv_conf_s since nginx 1.16.6