### PR TITLE
supporting current versions of nginx (fixes #57)

### DIFF
--- a/src/ngx_postgres_module.c
+++ b/src/ngx_postgres_module.c
@@ -1320,12 +1320,14 @@ ngx_postgres_find_upstream(ngx_http_request_t *r, ngx_url_t *url)
             continue;
         }
 
+#if (nginx_version < 1011006)
         if (uscfp[i]->default_port && url->default_port
             && (uscfp[i]->default_port != url->default_port))
         {
             dd("default_port doesn't match");
             continue;
         }
+#endif
 
         dd("returning");
         return uscfp[i];


### PR DESCRIPTION
current versions of nginx do not provide the default port anymore. So the code will not compile with current versions.