### PR TITLE
Capture the request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,32 @@ all empty strings are by default escaped to `NULL` value. This behavior can be
 disabled by prefixing `$unescaped` string with `=` sign.
 
 
+postgres_escape_request_body
+-----------------------
+* **syntax**: `postgres_request_body_escape on/off`
+* **default**: `on`
+* **context**: `location`
+
+The flag provides to double each single quote symbol
+in the complex SQL statements that contain substitutions from client http request body.
+Disabling this option is pretty dangerous.
+
+Please make sure you are NOT using postgres configuration option `standard_conforming_strings: off` (default for PostgreSQL < 9.1).
+Using `standard_conforming_strings: off` will make completely worthless the injection protection and allows an attacker to use control characters to change a query string.
+
+To check this option use: (correct setting below)
+```
+postgres=# SHOW standard_conforming_strings;
+
+Set timeout for receiving result from the database.
+
+ standard_conforming_strings
+-----------------------------
+ on
+(1 row)
+```
+
+
 postgres_connect_timeout
 ------------------------
 * **syntax**: `postgres_connect_timeout timeout`
@@ -159,8 +185,6 @@ postgres_result_timeout
 * **syntax**: `postgres_result_timeout timeout`
 * **default**: `30s`
 * **context**: `http`, `server`, `location`
-
-Set timeout for receiving result from the database.
 
 
 Configuration variables
@@ -382,9 +406,9 @@ by running:
 
 License
 =======
-    Copyright (c) 2010, FRiCKLE Piotr Sikora <info@frickle.com>
-    Copyright (c) 2009-2010, Xiaozhe Wang <chaoslawful@gmail.com>
-    Copyright (c) 2009-2010, Yichun Zhang <agentzh@gmail.com>
+    Copyright (c) 2010-2017, FRiCKLE Piotr Sikora <info@frickle.com>
+    Copyright (c) 2009-2017, Xiaozhe Wang <chaoslawful@gmail.com>
+    Copyright (c) 2009-2017, Yichun Zhang <agentzh@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Required modules (other than `ngx_postgres`):
 
 - [ngx_rds_json](http://github.com/agentzh/rds-json-nginx-module).
 
+
 Sample configuration #6
 -----------------------
 Use GET parameter in SQL query.
@@ -382,6 +383,24 @@ Use GET parameter in SQL query.
 Required modules (other than `ngx_postgres`):
 
 - [ngx_set_misc](http://github.com/agentzh/set-misc-nginx-module).
+
+
+Sample configuration #7
+-----------------------
+Use POST data to parameter in SQL query.
+
+    location /sms/(?<id>\d+) {
+        postgres_pass     database;
+        postgres_escape   $id;
+        postgres_query    POST      "UPDATE sms SET sms_recipt = '$request_body' WHERE id=$id RETURNING 'ACK'";
+        postgres_rewrite  POST      changes 200;
+        postgres_rewrite  POST      no_changes 410;
+        postgres_output   value;
+    }
+
+The variable `request_body` cannot be processed by the `postgres_escape` directive during the rewrite phase. Therefore, for security reasons, the  `request_body` value that is used in `postgres_query` is always processing to escape string literals during the content phase without the need for `postgres_escape`.
+
+This behavior can be disabled by directive `postgres_escape_request_body off`.
 
 Testing
 =======

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ postgres_result_timeout
 * **default**: `30s`
 * **context**: `http`, `server`, `location`
 
+Set timeout for receiving result from the database.
+
 
 Configuration variables
 =======================
@@ -406,9 +408,9 @@ by running:
 
 License
 =======
-    Copyright (c) 2010-2017, FRiCKLE Piotr Sikora <info@frickle.com>
-    Copyright (c) 2009-2017, Xiaozhe Wang <chaoslawful@gmail.com>
-    Copyright (c) 2009-2017, Yichun Zhang <agentzh@gmail.com>
+    Copyright (c) 2010, FRiCKLE Piotr Sikora <info@frickle.com>
+    Copyright (c) 2009-2010, Xiaozhe Wang <chaoslawful@gmail.com>
+    Copyright (c) 2009-2010, Yichun Zhang <agentzh@gmail.com>
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without

--- a/src/ngx_postgres_escape.c
+++ b/src/ngx_postgres_escape.c
@@ -31,10 +31,11 @@
 #include "ngx_postgres_ddebug.h"
 #include "ngx_postgres_escape.h"
 #include "ngx_postgres_module.h"
+#include "ngx_postgres_util.h"
 
 #include <libpq-fe.h>
 
-
+#define SINGLE_QUOTE_CHAR 39 /* ASCII code of Apostrophe = 39 */
 uintptr_t ngx_postgres_script_exit_code = (uintptr_t) NULL;
 
 
@@ -95,3 +96,134 @@ done:
     v->no_cacheable = 0;
     v->not_found = 0;
 }
+
+
+/* Purpose: calculate new length (with doubled quotes) for variable value.
+ * This method returns number of the single qoute characters (apostrophes)
+ * plus original length of text value */
+size_t
+ngx_postgres_upstream_var_len_with_quotes(ngx_http_script_engine_t *e)
+{
+    size_t                        i;
+    size_t                        result;
+    size_t                        count;
+    ngx_http_script_var_code_t   *code;
+    ngx_http_variable_value_t    *value;
+    ngx_http_core_main_conf_t    *cmcf;
+    ngx_http_variable_t          *v;
+    ngx_http_request_t           *r;
+
+    dd("entering");
+    result = 0;
+    count = 0;
+
+    if ((e != NULL) && (e->ip != NULL) && (e->request != NULL)) {
+        code = (ngx_http_script_var_code_t *) e->ip;
+        e->ip += sizeof(ngx_http_script_var_code_t);
+
+        if (!e->skip) {
+            if (e->flushed) {
+                value = ngx_http_get_indexed_variable(e->request, code->index);
+
+            } else {
+                value = ngx_http_get_flushed_variable(e->request, code->index);
+            }
+
+            if ((value != NULL) && (!value->not_found)) {
+                r = e->request;
+                cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+                v = cmcf->variables.elts;
+
+                if (v[code->index].get_handler ==
+                        (ngx_http_get_variable_pt)ngx_postgres_rewrite_var) {
+                    /* Quotes already escaped. Do nothing. */
+                    return value->len;
+                }
+
+                for (i = 0; i < value->len; i++) {
+                    if (value->data[i] == SINGLE_QUOTE_CHAR) {
+                        count++;
+                    }
+                }
+
+                result = value->len + count;
+                ngx_log_debug1(NGX_LOG_DEBUG_HTTP, e->request->connection->log,
+                    0, "http script: postgres: count to replace = %d", count);
+            }
+        }
+    }
+    dd("returning");
+
+    return result;
+}
+
+
+/* Purpose: replace quotes in variable values before substitute them in a query
+ * This method doubles the single qoute character (example: Can't -> Can''t) */
+void
+ngx_postgres_upstream_replace_quotes(ngx_http_script_engine_t *e)
+{
+    int                           i;
+    int                           k;
+    u_char                       *p;
+    u_char                       *data;
+    ngx_http_script_var_code_t   *code;
+    ngx_http_variable_value_t    *value;
+    ngx_http_core_main_conf_t    *cmcf;
+    ngx_http_variable_t          *v;
+    ngx_http_request_t           *r;
+
+    dd("entering");
+
+    if ((e != NULL) && (e->ip != NULL) && (e->request != NULL)) {
+        code = (ngx_http_script_var_code_t *) e->ip;
+
+        e->ip += sizeof(ngx_http_script_var_code_t);
+
+        if (!e->skip) {
+            if (e->flushed) {
+                value = ngx_http_get_indexed_variable(e->request, code->index);
+
+            } else {
+                value = ngx_http_get_flushed_variable(e->request, code->index);
+            }
+
+            if ((value != NULL) && (!value->not_found)
+                                && (e->buf.data != NULL)) {
+                p = e->pos;
+                data = value->data;
+
+                r = e->request;
+                cmcf = ngx_http_get_module_main_conf(r, ngx_http_core_module);
+                v = cmcf->variables.elts;
+
+                if (v[code->index].get_handler ==
+                        (ngx_http_get_variable_pt) ngx_postgres_rewrite_var) {
+                    /* Quotes already escaped. Do nothing. */
+                    return;
+                }
+
+                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                    "http script: postgres: replace quotes in $%V (\"%v\")",
+                    &v[code->index].name, value);
+
+                /* copy var value like ngx_http_script_copy_var_code(e) does */
+                for (i = 0, k = 0; i < value->len; i++, k++) {
+                    /* doubles all the qoute characters,
+                     * do not double backslashes */
+                    if (data[i] == SINGLE_QUOTE_CHAR) {
+                        p[k] = data[i];
+                        k++;
+                    }
+
+                    p[k] = data[i];
+                }
+
+                e->pos += k;
+            }
+        }
+    }
+
+    dd("returning");
+}
+

--- a/src/ngx_postgres_escape.h
+++ b/src/ngx_postgres_escape.h
@@ -31,6 +31,7 @@
 #include <ngx_http.h>
 
 
-void       ngx_postgres_escape_string(ngx_http_script_engine_t *);
-
+void     ngx_postgres_escape_string(ngx_http_script_engine_t *);
+size_t   ngx_postgres_upstream_var_len_with_quotes(ngx_http_script_engine_t *e);
+void     ngx_postgres_upstream_replace_quotes(ngx_http_script_engine_t *e);
 #endif /* _NGX_POSTGRES_ESCAPE_H_ */

--- a/src/ngx_postgres_handler.h
+++ b/src/ngx_postgres_handler.h
@@ -34,6 +34,8 @@
 
 
 ngx_int_t  ngx_postgres_handler(ngx_http_request_t *);
+ngx_int_t  ngx_postgres_read_req_body(ngx_http_request_t *r);
+void       ngx_postgres_body_handler(ngx_http_request_t *r);
 void       ngx_postgres_wev_handler(ngx_http_request_t *,
                ngx_http_upstream_t *);
 void       ngx_postgres_rev_handler(ngx_http_request_t *,

--- a/src/ngx_postgres_module.h
+++ b/src/ngx_postgres_module.h
@@ -161,6 +161,10 @@ typedef struct {
     unsigned                            output_binary:1;
     /* custom variables */
     ngx_array_t                        *variables;
+    /* request body substitution mode */
+    /* on - adds escape symbols to quote symbols */
+    /* off - copy request body into sql with no changes */
+    ngx_flag_t                          escape_request_body;
 } ngx_postgres_loc_conf_t;
 
 typedef struct {
@@ -171,6 +175,10 @@ typedef struct {
     ngx_str_t                           var_query;
     ngx_array_t                        *variables;
     ngx_int_t                           status;
+    /* Flag to save state of request body recive
+     *   true - waiting for more request body data;
+     *   false - no need to wait */
+    ngx_flag_t                          waiting_more_body:1;
 } ngx_postgres_ctx_t;
 
 

--- a/t/request_body.t
+++ b/t/request_body.t
@@ -1,0 +1,73 @@
+# vi:filetype=perl
+
+use lib 'lib';
+use Test::Nginx::Socket;
+
+plan tests => repeat_each() * (2 + 2 + 1);
+
+$ENV{TEST_NGINX_POSTGRESQL_HOST} ||= '127.0.0.1';
+$ENV{TEST_NGINX_POSTGRESQL_PORT} ||= 5432;
+
+our $http_config = <<'_EOC_';
+    upstream database {
+        postgres_server  $TEST_NGINX_POSTGRESQL_HOST:$TEST_NGINX_POSTGRESQL_PORT
+                         dbname=ngx_test user=ngx_test password=ngx_test;
+    }
+_EOC_
+
+no_shuffle();
+run_tests();
+
+__DATA__
+
+=== TEST 1: capture request body
+--- http_config eval: $::http_config
+--- config
+    location /test {
+        postgres_pass                database;
+        postgres_query               POST "SELECT '$request_body'";
+        postgres_output              value;
+    }
+--- request eval
+"POST /test
+{ test: \"My simple request\" }"
+--- error_code: 200
+--- response_body eval
+"{ test: \"My simple request\" }"
+--- timeout: 10
+
+
+
+=== TEST 2: escape request body
+--- http_config eval: $::http_config
+--- config
+    location /test {
+        postgres_pass                database;
+        postgres_query               POST "SELECT '$request_body'";
+        postgres_output              value;
+    }
+--- request eval
+"POST /test
+'; SQL injection attempt;"
+--- error_code: 200
+--- response_body eval
+"'; SQL injection attempt;"
+--- timeout: 10
+
+
+
+=== TEST 3: escape request body disabled
+--- http_config eval: $::http_config
+--- config
+    location /test {
+        postgres_escape_request_body off;
+        postgres_pass                database;
+        postgres_query               POST "SELECT '$request_body'";
+        postgres_output              value;
+    }
+--- request eval
+"POST /test
+'; SQL injection attempt;--"
+--- error_code: 500
+--- timeout: 10
+


### PR DESCRIPTION
This PR makes the following changes
- (new feature) The ngx_postgres module do not discard request body anymore. The request body is captured and can be used in requests.
- The request body is processed to escape string literals before substitution.

Description
-------------
Now nginx will read the entire request body in the content step if the `postgres_query` directive was used. '$request_body' variable can now be used in sql query string.

The variable `request_body` cannot be processed by the `postgres_escape` directive during the rewrite phase. Therefore, for security reasons, the  `request_body` value that is used in `postgres_query` is always processing to escape string literals during the content phase without the need for `postgres_escape`.

This behavior can be disabled by directive `postgres_escape_request_body off`.

Added tests to check behavior when using the request body. Added a configuration sample in the readme.

Changes for supporting current versions of nginx (fixes #57) included.